### PR TITLE
Remove 'open citizenship' section from CoC and pull up a couple of sentences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+### Building
+
+1. Install Jekyll locally. See [Jekyll](http://jekyllrb.com)
+2. Clone this repo.
+3. Change into the directory.
+4. `jekyll build`
+
+
+### Contributing
+
+We welcome contributions via pull-requests. All contributors must abide by our [Code of Conduct](http://queer-code.org/coc.html).

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,6 +6,7 @@
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.3.1/css/bulma.min.css"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
+    <link rel="stylesheet" href="styles.css"/>
 </head>
 <body>
 

--- a/_layouts/text.html
+++ b/_layouts/text.html
@@ -1,6 +1,6 @@
 {% include header.html %}
 
-<div class="content notification">
+<div class="content">
 
     {{ content }}
 

--- a/coc.md
+++ b/coc.md
@@ -11,14 +11,9 @@ This Code of Conduct outlines our expectations for all those who participate in 
 
 We invite all those who participate in our events to help us create safe and positive experiences for everyone.
 
+**Don’t be scared off by these rules! They are in place to protect us, not to intimidate people from interacting with each other in a positive manner or from exploring gender and sexuality.**
 
-## Open [Source/Culture/Tech] Citizenship
-
-A supplemental goal of this Code of Conduct is to increase open [source/culture/tech] citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
-
-Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
-
-If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
+This code of conduct is [open to any suggestions](https://github.com/QueerCodeBerlin/queercodeberlin.github.io//edit/master/coc.md){:target="_blank"} and [criticism](mailto:queer-code-berlin@googlegroups.com){:target="_blank"}: we are happy to learn and improve. You can also see the [history of this document](https://github.com/QueerCodeBerlin/queercodeberlin.github.io/commits/master/coc.md){:target="_blank"} if you're interested. 
 
 
 ## Expected Behavior
@@ -82,14 +77,9 @@ We expect all community participants (contributors, paid or otherwise; sponsors;
 
 By creating this CoC, we help foster a safer space which “might be less about an absolute security in which there is no risk, no pain and no difficult conversations, but rather more about a redistribution of the risks and discomforts of speaking and organizing” (Dreher 2009,p.17).
 
-**Don’t be scared off by these rules! They are in place to protect us, not to intimidate people from interacting with each other in a positive manner or from exploring gender and sexuality.**
-
 We would prefer to live in a society where we do not need Codes of Conduct. However, Codes of Conduct are essential to establish spaces that are different from – and more inclusive than – general society. If you don’t set up your own rules, you implicitly endorse those prevalent in society – including the unwritten ones – many of which we recognize as unfair to many people. When privileges are not explicitly addressed by the ethos of a space, the burden of education will often be placed upon the people who are living the oppressions. Moreover, since we still perform – consciously or unconsciously – behaviours that have oppressive potential (i.e. patriarchal, racist, sexist, capitalist, (neo)colonialist, etc.), it is essential to reflect on our privileges and on the ways in which they have an impact on our lives and the lives of others.
 
 **A code of conduct can help do just that: to bring awareness, consciousness, reflexivity and ultimately change.**
-
-This code of conduct is [open to any suggestions](https://github.com/QueerCodeBerlin/queercodeberlin.github.io//edit/master/coc.md){:target="_blank"} and [criticism](mailto:queer-code-berlin@googlegroups.com){:target="_blank"}: we are happy to learn and improve. You can also see the [history of this document](https://github.com/QueerCodeBerlin/queercodeberlin.github.io/commits/master/coc.md){:target="_blank"} if you're interested. 
-
 
 ## Licence and  Attribution
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,6 @@
+.content {
+  font-size: 1.3em;
+  line-height: 1.8em;
+  max-width: 700px;
+  margin: auto;
+}


### PR DESCRIPTION
@egga These are changes we came up with during Queer Code yesterday. We believe we want to keep the Berlin & London CoCs together as one (rather than splitting them out), so these are the changes we think are necessary for that to happen.

1 - remove the paragraphs on Open Citizenship. It doesn't seem to be directly related to conduct. This would be nice to put elsewhere on the site as a value (or maybe on the Mission page).
2 - pull up a couple of sentences from the bottom to the top. We think this helps make the CoC more approachable.

Thanks! 